### PR TITLE
fix requests::set_cookies  function

### DIFF
--- a/core/requests.php
+++ b/core/requests.php
@@ -115,19 +115,21 @@ class requests
 
         foreach ($cookies_arr as $cookie) 
         {
-            $cookie_arr = explode("=", $cookie);
-            $key = $value = "";
-            foreach ($cookie_arr as $k=>$v) 
-            {
-                if ($k == 0) 
-                {
-                    $key = trim($v);
-                }
-                else 
-                {
-                    $value .= trim(str_replace('"', '', $v));
-                }
-            }
+#            $cookie_arr = explode("=", $cookie);
+#            $key = $value = "";
+#            foreach ($cookie_arr as $k=>$v) 
+#            {
+#                if ($k == 0) 
+#                {
+#                    $key = trim($v);
+#                }
+#                else 
+#                {
+#                    $value .= trim(str_replace('"', '', $v));
+#                }
+#            }
+            $key = strstr($cookie,'=',true);
+            $value = substr(strstr($cookie,'='),1);
 
             if (!empty($domain)) 
             {


### PR DESCRIPTION
    原来的requests::set_cookies处理一般的cookies没问题，但是当遇到cookies字符串里有“=”号时，处理逻辑就有问题了，这样设置的cookies没法用，我做了点修改，更简单一点，至少我使用中没什么问题。