### PR TITLE
添加完整的编码方式属性，DOMDocument::loadHTML才能正确识别UTF-8

### DIFF
--- a/core/requests.php
+++ b/core/requests.php
@@ -303,7 +303,7 @@ class requests
             // 先将非utf8编码,转化为utf8编码
             $body = @mb_convert_encoding($body, self::$output_encoding, self::$input_encoding);
             // 将页面中的指定的编码方式修改为utf8
-            $body = preg_replace("/<meta([^>]*)charset=([^>]*)>/is", '<meta charset="UTF-8">', $body);
+            $body = preg_replace("/<meta([^>]*)charset=([^>]*)>/is", '<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>', $body);
             // 直接干掉头部，国外很多信息是在头部的
             //$body = self::_remove_head($body);
         }


### PR DESCRIPTION
比如，demo中京华网页面(http://news.jinghua.cn/20161205/f256601.shtml)抓取会进到这个分支，不使用完整属性抓取结果中文是乱码。