### PR TITLE
修复当传入post数据为json的错误

### DIFF
--- a/core/requests.php
+++ b/core/requests.php
@@ -646,8 +646,12 @@ class requests
                 }
                 else 
                 {
-                    // 某些server可能会有问题
-                    $fields = array_merge($fields, $file_fields);
+                    if (!is_null($stance = json_decode($fields, true))) {
+                        $fields = json_encode(array_merge($stance, $file_fields));
+                    } else {
+                        // 某些server可能会有问题
+                        $fields = array_merge($fields, $file_fields);
+                    }
                 }
                 // 不能直接传数组，不知道是什么Bug，会非常慢
                 curl_setopt( self::$ch, CURLOPT_POSTFIELDS, $fields );


### PR DESCRIPTION
当传入json格式数据，由于没有转义而直接报错，由此加一层解释，不能转为http_build或数组，否则post数据无法响应