### PR TITLE
修复开启多任务未配置queue_config参数导致的错误

### DIFF
--- a/core/phpspider.php
+++ b/core/phpspider.php
@@ -455,6 +455,12 @@ class phpspider
             self::$tasknum = $configs['tasknum'];
         }
 
+        if (isset($configs['tasknum']) && $configs['tasknum'] > 1 && !isset($configs['queue_config'])){
+            $msg = "Please configure parameters to enable multi-process 'queue_config'";
+            log::error($msg);
+            exit;
+        }
+
         // 是否设置了保留运行状态
         if (isset($configs['save_running_state'])) 
         {


### PR DESCRIPTION
设置多任务，如果没有设置队列配置的话会导致程序允许错误，现在添加了错误提醒