### PR TITLE
修复不兼容php8语法导致的错误

### DIFF
--- a/core/phpspider.php
+++ b/core/phpspider.php
@@ -2440,7 +2440,7 @@ class phpspider
      * @author seatle <seatle@foxmail.com> 
      * @created time :2016-10-30 23:56
      */
-    public function get_task_status_list($serverid = 1, $tasknum)
+    public function get_task_status_list($serverid = 1, $tasknum = 1)
     {
         $task_status = array();
         if (self::$use_redis)

--- a/core/util.php
+++ b/core/util.php
@@ -341,11 +341,11 @@ class util
      */
     public static function letter_first($s0)
     {
-        $firstchar_ord = ord(strtoupper($s0[0]));
-        if (($firstchar_ord >= 65 and $firstchar_ord <= 91) or ($firstchar_ord >= 48 and $firstchar_ord <= 57)) return $s0[0];
+        $firstchar_ord = ord(strtoupper(substr($s0, 0, 1)));
+        if (($firstchar_ord >= 65 and $firstchar_ord <= 91) or ($firstchar_ord >= 48 and $firstchar_ord <= 57)) return substr($s0, 0, 1);
         // $s = iconv("utf-8", "gbk//ignore", $s0);
         $s = mb_convert_encoding($s0, "gbk", "utf-8");
-        $asc = ord($s[0]) * 256 + ord($s[1]) - 65536;
+        $asc = ord(substr($s, 0, 1)) * 256 + ord(substr($s, 1, 1)) - 65536;
         if ($asc >= -20319 and $asc <= -20284) return "A";
         if ($asc >= -20283 and $asc <= -19776) return "B";
         if ($asc >= -19775 and $asc <= -19219) return "C";


### PR DESCRIPTION
修复了运行时语法报错。

已弃用:可选参数$serverid声明在必选参数$tasknum之前，在/home/work/src/ comer /src/vendor/owner88 /phpspider/core/phpspider. PHP第2443行隐式地视为必选参数

已弃用:在必填参数$tasknum之前声明的可选参数$serverid在/home/work/src/ comper /src/vendor/owner88 /phpspider/core/phpspider.php第2443行隐式地视为必填参数

/home/work/src/composer/src/vendor/owner888/phpspider/core/util.php第343行不再支持带花括号的数组和字符串偏移访问语法

/home/work/src/composer/src/vendor/owner888/phpspider/core/util.php第343行不再支持带花括号的数组和字符串偏移访问语法